### PR TITLE
brokerd: fix error template name & add missing docker-compose env

### DIFF
--- a/cmd/brokerd/service/service.go
+++ b/cmd/brokerd/service/service.go
@@ -87,7 +87,7 @@ func New(config Config) (*Service, error) {
 
 	dealer, err := dealeri.New(config.DealerAddr)
 	if err != nil {
-		return nil, fmt.Errorf("creating auctioneer implementation: %s", err)
+		return nil, fmt.Errorf("creating dealer implementation: %s", err)
 	}
 
 	broker, err := brokeri.New(ds, packer, piecer, auctioneer, dealer, config.DealEpochs)

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -96,6 +96,7 @@ services:
       - BROKER_IPFS_MULTIADDR=/dns4/ipfs/tcp/5001
       - BROKER_PACKER_ADDR=packerd:5000
       - BROKER_AUCTIONEER_ADDR=auctioneerd:5000
+      - BROKER_DEALER_ADDR=dealerd:5000
       - BROKER_DEAL_EPOCHS=1051200
     security_opt:
       - "seccomp:unconfined"


### PR DESCRIPTION
The title says it all.