### PR TITLE
storaged/bench: allow size range, freq and count

### DIFF
--- a/cmd/storaged/bench.sh
+++ b/cmd/storaged/bench.sh
@@ -1,25 +1,27 @@
 #!/bin/bash
 set -euo pipefail
 
-if [ "$#" -ne 2 ]; then
-	echo "use $0 <target-url> <size>"
-	exit -1
-fi
-
 checkEnv() {
     if [[ -z ${!1+set} ]]; then
        echo "Oop! Need to define the $1 environment variable"
        exit 1
     fi
 }
-
-TARGET="${1}/upload"
-SIZE=$2
-TOKEN="Bearer eyJhbGciOiJFZERTQVNoYTI1NiIsInR5cCI6IkpXVCIsImp3ayI6eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6IlYyZmNCUTJudHE3VDJ4UFpjVkVMVTFhUEstaGhHVTZzOENrZ2M1R3lSSVU9IiwidXNlIjoic2lnIn19.eyJhdWQiOiJsb2NrLWJveC50ZXN0bmV0IiwiaXNzIjoibG9jay1ib3gudGVzdG5ldCIsInN1YiI6ImRpZDprZXk6ejZNa2tMVE5NYzRoRVN1UlR5QVVRelBjajNIRnRZNjZkNjJWNjNMNW1ZN0pFdDRMIiwibmJmIjoxNjIwMzIwNzM2LCJpYXQiOjE2MjAzMjA3MzYsImV4cCI6MTAwMDAwMDAxNjIwMzIwNzQwfQ==.E4eLnR7sXvne-r3aV4XwjVhThmu85HSEoE83IpTF1vDp71zgO_DAbhOT4o0PGpfTo-P6kXLKX1ixdZ6fgmMEBA=="
-
 checkEnv SEED_PHRASE
 
-echo $TARGET
+if [ "$#" -le 1 ]; then
+	echo "use $0 <target-url> <min-size> <max-size:opt> <count:opt> <sleep:opt>"
+	exit -1
+fi
+
+TARGET="${1}/upload"
+MIN_SIZE=$2
+MAX_SIZE=${3:-$MIN_SIZE}
+COUNT=${4:-1}
+TOKEN="Bearer eyJhbGciOiJFZERTQVNoYTI1NiIsInR5cCI6IkpXVCIsImp3ayI6eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6IlYyZmNCUTJudHE3VDJ4UFpjVkVMVTFhUEstaGhHVTZzOENrZ2M1R3lSSVU9IiwidXNlIjoic2lnIn19.eyJhdWQiOiJsb2NrLWJveC50ZXN0bmV0IiwiaXNzIjoibG9jay1ib3gudGVzdG5ldCIsInN1YiI6ImRpZDprZXk6ejZNa2tMVE5NYzRoRVN1UlR5QVVRelBjajNIRnRZNjZkNjJWNjNMNW1ZN0pFdDRMIiwibmJmIjoxNjIwMzIwNzM2LCJpYXQiOjE2MjAzMjA3MzYsImV4cCI6MTAwMDAwMDAxNjIwMzIwNzQwfQ==.E4eLnR7sXvne-r3aV4XwjVhThmu85HSEoE83IpTF1vDp71zgO_DAbhOT4o0PGpfTo-P6kXLKX1ixdZ6fgmMEBA=="
+SLEEP=${5:-0}
+
+echo "Hitting $TARGET with sizes [$MIN_SIZE, $MAX_SIZE] for $COUNT times..."
 
 echo "Locking funds on NEAR..."
 near call lock-box.testnet lockFunds '{ "brokerId": "lock-box.testnet", "accountId": "lock-box.testnet" }' \
@@ -27,12 +29,16 @@ near call lock-box.testnet lockFunds '{ "brokerId": "lock-box.testnet", "account
 --amount 1 \
 --seedPhrase "$SEED_PHRASE"
 
-echo "Generating random file..."
-TMPFILE=$(mktemp)
-head -c ${SIZE} < /dev/urandom > $TMPFILE
+i=1
+while ((i<=$COUNT)); do
+  SIZE=$(($RANDOM*($MAX_SIZE-$MIN_SIZE+1)/32767 + $MIN_SIZE))
+  TMPFILE=$(mktemp)
+  head -c ${SIZE} < /dev/urandom > $TMPFILE
 
-echo "Uploading file..."
-curl -v -H "Authorization: $TOKEN" -F "region=europe" -F "file=@$TMPFILE" $TARGET
+  echo "Uploading file of size $SIZE..."
+  curl -H "Authorization: $TOKEN" -F "region=europe" -F "file=@$TMPFILE" $TARGET
 
-echo "Cleaning..."
-rm $TMPFILE
+  rm $TMPFILE
+  let i++
+  sleep $SLEEP
+done;


### PR DESCRIPTION
This PR extends `bench.sh` to:
- Allow specifying a range of a sizes range, to generate data of random size within that range.
- Allow specifying a `count`, as to allow uploading multiple files at the same time.
- Allow specifying some sleep between multi-uploads.

For example, `bench.sh 127.0.0.1:8888 100 200 10 0.1`: generates 10 random files between 100 and 200 bytes, while sleeping 0.1s between uploads.