### PR TITLE
Better insight into SC errors

### DIFF
--- a/cmd/neard/nearclient/account/types.go
+++ b/cmd/neard/nearclient/account/types.go
@@ -58,16 +58,10 @@ type FunctionCallPermissionView struct {
 	FunctionCall FunctionCall `json:"FunctionCall"`
 }
 
-// ExecutionError describes a failed transaction error.
-type ExecutionError struct {
-	ErrorMessage string `json:"error_message"`
-	ErrorType    string `json:"error_type"`
-}
-
 // FinalExecutionStatus is the final status of a transaction.
 type FinalExecutionStatus struct {
-	SuccessValue string          `json:"SuccessValue"`
-	Failure      *ExecutionError `json:"Failure,omitempty"`
+	SuccessValue string                 `json:"SuccessValue"`
+	Failure      map[string]interface{} `json:"Failure,omitempty"`
 }
 
 // FinalExecutionStatusBasic is the final status of a transaction.
@@ -84,9 +78,9 @@ const (
 
 // ExecutionStatus is the status of a transaction.
 type ExecutionStatus struct {
-	SuccessValue     string          `json:"SuccessValue"`
-	SuccessReceiptID string          `json:"SuccessReceiptId"`
-	Failure          *ExecutionError `json:"Failure"`
+	SuccessValue     string                 `json:"SuccessValue"`
+	SuccessReceiptID string                 `json:"SuccessReceiptId"`
+	Failure          map[string]interface{} `json:"Failure,omitempty"`
 }
 
 // ExecutionStatusBasic is the status of a transaction.


### PR DESCRIPTION
The error data returned when there is an error returned from a smart contract function or some other bockchain error is a huge and dynamic beast. Doesn't jive well with Golang. I'm working more to understand the best way to handle and model these errors, but for now, just decoding into a `map[string]interface` and returning a Go error with a json string representation of the error object is enough so the caller can at least understand what is wrong. And example of the error returned from the NEAR go client would be like:
```
calling rpc: signing and sending transaction: status failure: {
  "ActionError": {
    "index": 0,
    "kind": {
      "FunctionCallError": {
        "ExecutionError": "Smart contract panicked: addDeposit: invalid attached deposit, filename: \"assembly/main.ts\" line: 29 col: 5"
      }
    }
  }
}
```