### PR TITLE
k8/ipfs-cluster: use raft

### DIFF
--- a/k8/base/ipfs-cluster/cluster-setup-confmap.yaml
+++ b/k8/base/ipfs-cluster/cluster-setup-confmap.yaml
@@ -13,7 +13,7 @@ data:
     # allow changes on the fly.
 
     if [ ! -f /data/ipfs-cluster/service.json ]; then
-      ipfs-cluster-service init --consensus crdt
+      ipfs-cluster-service init
     fi
 
     PEER_HOSTNAME=`cat /proc/sys/kernel/hostname`


### PR DESCRIPTION
Lets give it a try to Raft since CRDT seems to eat a lot of storage in the `ipfs-cluster` PVC. That PVC isn't related with data itself, but with pinset managing.

Hopefully, we can confirm if Raft is a stable option for the short/medium term.