### PR TITLE
pubsub: adds publish options and better error handling

### DIFF
--- a/pubsub/options.go
+++ b/pubsub/options.go
@@ -1,0 +1,46 @@
+package pubsub
+
+import (
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+)
+
+// PublishOptions defines options for Publish.
+type PublishOptions struct {
+	ignoreResponse bool
+	multiResponse  bool
+	pubOpts        []pubsub.PubOpt
+}
+
+var defaultOptions = PublishOptions{
+	ignoreResponse: false,
+	multiResponse:  false,
+}
+
+// PublishOption defines a Publish option.
+type PublishOption func(*PublishOptions) error
+
+// WithIgnoreResponse indicates whether or not Publish will wait for a response(s) from the receiver(s).
+// Default: disabled.
+func WithIgnoreResponse(enable bool) PublishOption {
+	return func(args *PublishOptions) error {
+		args.ignoreResponse = enable
+		return nil
+	}
+}
+
+// WithMultiResponse indicates whether or not Publish will wait for multiple responses before returning.
+// Default: disabled.
+func WithMultiResponse(enable bool) PublishOption {
+	return func(args *PublishOptions) error {
+		args.multiResponse = enable
+		return nil
+	}
+}
+
+// WithPubOpts sets native pubsub.PubOpt options.
+func WithPubOpts(opts ...pubsub.PubOpt) PublishOption {
+	return func(args *PublishOptions) error {
+		args.pubOpts = opts
+		return nil
+	}
+}


### PR DESCRIPTION
I started this thinking we needed to do away with the separate bids topic that's used to collect bids in order to enable multiple auctioneers, instead using a "multi" response option with `Publish`. I realized that we can't do that since the auctioneer needs to reply to bids with a bid ID, meaning that bids can't themselves be submitted as responses to an auction. However, we can still use multiple auctioneers with the current setup since bids are received over an auction-specific topic; only one auctioneer will be listening to that topic. 

I kept the pubsub changes since they include some better error handling and general API improvements.