### PR TITLE
auctioneerd: print peer info as part of the startup sequence

### DIFF
--- a/cmd/auctioneerd/client/client_test.go
+++ b/cmd/auctioneerd/client/client_test.go
@@ -272,7 +272,9 @@ func addBidbots(t *testing.T, n int) map[peer.ID]*bidbotsrv.Service {
 		err = s.Subscribe(false)
 		require.NoError(t, err)
 
-		bots[s.Host().ID()] = s
+		pi, err := s.PeerInfo()
+		require.NoError(t, err)
+		bots[pi.ID] = s
 	}
 	return bots
 }

--- a/cmd/auctioneerd/main.go
+++ b/cmd/auctioneerd/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
 	_ "net/http/pprof"
@@ -148,9 +149,14 @@ var daemonCmd = &cobra.Command{
 		serv, err := service.New(config, store, broker, fc)
 		common.CheckErrf("starting service: %v", err)
 		fin.Add(serv)
-
 		err = serv.Start(true)
 		common.CheckErrf("creating deal auction feed: %v", err)
+
+		info, err := serv.PeerInfo()
+		common.CheckErrf("getting peer information: %v", err)
+		b, err := json.MarshalIndent(info, "", "\t")
+		common.CheckErrf("marshaling peer information: %v", err)
+		log.Infof("peer information:: %s", string(b))
 
 		common.HandleInterrupt(func() {
 			common.CheckErr(fin.Cleanupf("closing service: %v", nil))

--- a/cmd/auctioneerd/service/service.go
+++ b/cmd/auctioneerd/service/service.go
@@ -102,6 +102,11 @@ func (s *Service) DAGService() format.DAGService {
 	return s.peer.DAGService()
 }
 
+// PeerInfo returns the peer's public information.
+func (s *Service) PeerInfo() (*marketpeer.PeerInfo, error) {
+	return s.peer.Info()
+}
+
 // ReadyToAuction creates a new auction.
 func (s *Service) ReadyToAuction(_ context.Context, req *pb.ReadyToAuctionRequest) (*pb.ReadyToAuctionResponse, error) {
 	if req == nil {

--- a/cmd/bidbot/httpapi/httpapi.go
+++ b/cmd/bidbot/httpapi/httpapi.go
@@ -1,7 +1,6 @@
 package httpapi
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,12 +8,10 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/libp2p/go-libp2p-core/crypto"
-	"github.com/libp2p/go-libp2p-core/host"
-	ma "github.com/multiformats/go-multiaddr"
 	"github.com/textileio/broker-core/broker"
 	"github.com/textileio/broker-core/cmd/bidbot/service/datauri"
 	bidstore "github.com/textileio/broker-core/cmd/bidbot/service/store"
+	"github.com/textileio/broker-core/marketpeer"
 	golog "github.com/textileio/go-log/v2"
 )
 
@@ -24,7 +21,7 @@ var (
 
 // Service provides scoped access to the bidbot service.
 type Service interface {
-	Host() host.Host
+	PeerInfo() (*marketpeer.PeerInfo, error)
 	ListBids(query bidstore.Query) ([]*bidstore.Bid, error)
 	GetBid(id broker.BidID) (*bidstore.Bid, error)
 	WriteDataURI(payloadCid, uri string) (string, error)
@@ -77,27 +74,12 @@ func healthHandler(w http.ResponseWriter, _ *http.Request) {
 
 func idHandler(service Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		host := service.Host()
-		var pkey string
-		if pk := host.Peerstore().PubKey(host.ID()); pk != nil {
-			pkb, err := crypto.MarshalPublicKey(pk)
-			if err != nil {
-				httpError(w, fmt.Sprintf("marshaling public key: %s", err), http.StatusInternalServerError)
-				return
-			}
-			pkey = base64.StdEncoding.EncodeToString(pkb)
+		info, err := service.PeerInfo()
+		if err != nil {
+			httpError(w, err.Error(), http.StatusInternalServerError)
+			return
 		}
-
-		v := struct {
-			ID        string
-			PublicKey string
-			Addresses []ma.Multiaddr
-		}{
-			host.ID().String(),
-			pkey,
-			host.Addrs(),
-		}
-		data, err := json.MarshalIndent(v, "", "\t")
+		data, err := json.MarshalIndent(info, "", "\t")
 		if err != nil {
 			httpError(w, fmt.Sprintf("marshaling id: %s", err), http.StatusInternalServerError)
 			return

--- a/cmd/bidbot/httpapi/httpapi_test.go
+++ b/cmd/bidbot/httpapi/httpapi_test.go
@@ -9,13 +9,13 @@ import (
 	"testing"
 
 	"github.com/libp2p/go-libp2p-core/crypto"
-	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/textileio/broker-core/broker"
 	"github.com/textileio/broker-core/cmd/bidbot/service/datauri"
 	bidstore "github.com/textileio/broker-core/cmd/bidbot/service/store"
+	"github.com/textileio/broker-core/marketpeer"
 	golog "github.com/textileio/go-log/v2"
 )
 
@@ -150,7 +150,7 @@ type mockService struct {
 	mock.Mock
 }
 
-func (s *mockService) Host() host.Host {
+func (s *mockService) PeerInfo() (*marketpeer.PeerInfo, error) {
 	panic("not implemented")
 }
 


### PR DESCRIPTION
Instead of adding an HTTP API and something like `auctioneerd id`, this PR simply prints the information in logs, which should be sufficient for our use.