### PR TITLE
check store health before bidding; print stats periodically

### DIFF
--- a/cmd/auctioneerd/auctioneer/auctioneer.go
+++ b/cmd/auctioneerd/auctioneer/auctioneer.go
@@ -162,7 +162,7 @@ func (a *Auctioneer) Start(bootstrap bool) error {
 }
 
 // CreateAuction creates a new auction.
-// New auctions are queud if the auctioneer is busy.
+// New auctions are queued if the auctioneer is busy.
 func (a *Auctioneer) CreateAuction(auction core.Auction) (core.AuctionID, error) {
 	auction.Status = broker.AuctionStatusUnspecified
 	auction.Duration = a.auctionConf.Duration

--- a/cmd/auctioneerd/client/client_test.go
+++ b/cmd/auctioneerd/client/client_test.go
@@ -285,6 +285,7 @@ func newDealID() core.StorageDealID {
 
 func newLotusClientMock() *lotusclientmocks.LotusClient {
 	lc := &lotusclientmocks.LotusClient{}
+	lc.On("HealthCheck").Return(nil)
 	lc.On(
 		"ImportData",
 		mock.Anything,

--- a/cmd/bidbot/service/lotusclient/lotusclient.go
+++ b/cmd/bidbot/service/lotusclient/lotusclient.go
@@ -25,7 +25,6 @@ var (
 // LotusClient provides access to Lotus for importing deal data.
 type LotusClient interface {
 	io.Closer
-
 	HealthCheck() error
 	ImportData(pcid cid.Cid, file string) error
 }

--- a/cmd/bidbot/service/service_test.go
+++ b/cmd/bidbot/service/service_test.go
@@ -141,6 +141,7 @@ func TestNew(t *testing.T) {
 
 func newLotusClientMock() *lotusclientmocks.LotusClient {
 	lc := &lotusclientmocks.LotusClient{}
+	lc.On("HealthCheck").Return(nil)
 	lc.On(
 		"ImportData",
 		mock.Anything,

--- a/cmd/bidbot/service/store/store.go
+++ b/cmd/bidbot/service/store/store.go
@@ -493,9 +493,15 @@ func (s *Store) HealthCheck() error {
 	// make sure the directory is writable
 	f, err := ioutil.TempFile(s.dealDataDirectory, ".touch")
 	if err != nil {
-		return err
+		return fmt.Errorf("deal data directory: %v", err)
 	}
-	return os.Remove(f.Name())
+	if err = os.Remove(f.Name()); err != nil {
+		log.Errorf("removing temp file: %v", err)
+	}
+	if err := s.lc.HealthCheck(); err != nil {
+		return fmt.Errorf("lotus client: %v", err)
+	}
+	return nil
 }
 
 func (s *Store) dealDataFilePathFor(bidID broker.BidID, payloadCid string) string {

--- a/cmd/bidbot/service/store/store_test.go
+++ b/cmd/bidbot/service/store/store_test.go
@@ -271,6 +271,7 @@ func newStore(t *testing.T) (*Store, format.DAGService, blockstore.Blockstore) {
 
 func newLotusClientMock() *lotusclientmocks.LotusClient {
 	lc := &lotusclientmocks.LotusClient{}
+	lc.On("HealthCheck").Return(nil)
 	lc.On(
 		"ImportData",
 		mock.Anything,

--- a/marketpeer/marketpeer.go
+++ b/marketpeer/marketpeer.go
@@ -206,6 +206,11 @@ func (p *Peer) Info() (*PeerInfo, error) {
 	}, nil
 }
 
+// ListPeers returns the peers the market peer currently connects to.
+func (p *Peer) ListPeers() []peer.ID {
+	return p.ps.ListPeers("")
+}
+
 // Bootstrap the market peer against Config.Bootstrap network peers.
 // Some well-known network peers are included by default.
 func (p *Peer) Bootstrap() {

--- a/mocks/auctioneer/Auctioneer.go
+++ b/mocks/auctioneer/Auctioneer.go
@@ -51,20 +51,20 @@ func (_m *Auctioneer) ProposalAccepted(ctx context.Context, auID broker.AuctionI
 	return r0
 }
 
-// ReadyToAuction provides a mock function with given fields: ctx, id, dealSize, dealDuration, dealReplication, dealVerified, excludedMiners, filEpochDeadline, sources
-func (_m *Auctioneer) ReadyToAuction(ctx context.Context, id broker.StorageDealID, dealSize int, dealDuration int, dealReplication int, dealVerified bool, excludedMiners []string, filEpochDeadline *int64, sources broker.Sources) (broker.AuctionID, error) {
-	ret := _m.Called(ctx, id, dealSize, dealDuration, dealReplication, dealVerified, excludedMiners, filEpochDeadline, sources)
+// ReadyToAuction provides a mock function with given fields: ctx, id, payloadCid, dealSize, dealDuration, dealReplication, dealVerified, excludedMiners, filEpochDeadline, sources
+func (_m *Auctioneer) ReadyToAuction(ctx context.Context, id broker.StorageDealID, payloadCid cid.Cid, dealSize int, dealDuration int, dealReplication int, dealVerified bool, excludedMiners []string, filEpochDeadline uint64, sources broker.Sources) (broker.AuctionID, error) {
+	ret := _m.Called(ctx, id, payloadCid, dealSize, dealDuration, dealReplication, dealVerified, excludedMiners, filEpochDeadline, sources)
 
 	var r0 broker.AuctionID
-	if rf, ok := ret.Get(0).(func(context.Context, broker.StorageDealID, int, int, int, bool, []string, *int64, broker.Sources) broker.AuctionID); ok {
-		r0 = rf(ctx, id, dealSize, dealDuration, dealReplication, dealVerified, excludedMiners, filEpochDeadline, sources)
+	if rf, ok := ret.Get(0).(func(context.Context, broker.StorageDealID, cid.Cid, int, int, int, bool, []string, uint64, broker.Sources) broker.AuctionID); ok {
+		r0 = rf(ctx, id, payloadCid, dealSize, dealDuration, dealReplication, dealVerified, excludedMiners, filEpochDeadline, sources)
 	} else {
 		r0 = ret.Get(0).(broker.AuctionID)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, broker.StorageDealID, int, int, int, bool, []string, *int64, broker.Sources) error); ok {
-		r1 = rf(ctx, id, dealSize, dealDuration, dealReplication, dealVerified, excludedMiners, filEpochDeadline, sources)
+	if rf, ok := ret.Get(1).(func(context.Context, broker.StorageDealID, cid.Cid, int, int, int, bool, []string, uint64, broker.Sources) error); ok {
+		r1 = rf(ctx, id, payloadCid, dealSize, dealDuration, dealReplication, dealVerified, excludedMiners, filEpochDeadline, sources)
 	} else {
 		r1 = ret.Error(1)
 	}


### PR DESCRIPTION
This is to finish the health check project. After this PR bidbot will do following:
1. Check deals data directory writability and lotus client reachability on startup, before bidding, and every 10 minutes;
2. Print bidbot up time and number of connected peers every 10 minutes.

Number of connected peers looks like a good proxy of whether the bidbot connects to the network or not. The peers can be either auctioneerd or other bidbots. I tested that when killing one peer, it immediately disappeared from `ListPeers` call from other peers.