### PR TITLE
cache go mod files when building daemons

### DIFF
--- a/cmd/auctioneerd/Dockerfile
+++ b/cmd/auctioneerd/Dockerfile
@@ -6,9 +6,9 @@ RUN mkdir /app
 WORKDIR /app
 
 COPY go.mod go.sum ./
-RUN go mod download -x
+RUN --mount=type=cache,target=/go/pkg/mod go mod download -x
 COPY . .
-RUN --mount=type=cache,target=/root/.cache/go-build \
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
   BIN_BUILD_FLAGS="CGO_ENABLED=0 GOOS=linux" make build-auctioneerd
 
 FROM alpine

--- a/cmd/authd/Dockerfile
+++ b/cmd/authd/Dockerfile
@@ -6,9 +6,9 @@ RUN mkdir /app
 WORKDIR /app
 
 COPY go.mod go.sum ./
-RUN go mod download -x
+RUN --mount=type=cache,target=/go/pkg/mod go mod download -x
 COPY . .
-RUN --mount=type=cache,target=/root/.cache/go-build \
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
   BIN_BUILD_FLAGS="CGO_ENABLED=0 GOOS=linux" make build-authd
 
 FROM alpine

--- a/cmd/brokerd/Dockerfile
+++ b/cmd/brokerd/Dockerfile
@@ -6,9 +6,9 @@ RUN mkdir /app
 WORKDIR /app
 
 COPY go.mod go.sum ./
-RUN go mod download -x
+RUN --mount=type=cache,target=/go/pkg/mod go mod download -x
 COPY . .
-RUN --mount=type=cache,target=/root/.cache/go-build \
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
   BIN_BUILD_FLAGS="CGO_ENABLED=0 GOOS=linux" make build-brokerd
 
 FROM alpine

--- a/cmd/dealerd/Dockerfile
+++ b/cmd/dealerd/Dockerfile
@@ -6,9 +6,9 @@ RUN mkdir /app
 WORKDIR /app 
 
 COPY go.mod go.sum ./
-RUN go mod download -x
+RUN --mount=type=cache,target=/go/pkg/mod go mod download -x
 COPY . .
-RUN --mount=type=cache,target=/root/.cache/go-build \
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
   GOOS=linux make build-dealerd
 
 FROM busybox:1-glibc

--- a/cmd/neard/Dockerfile
+++ b/cmd/neard/Dockerfile
@@ -6,9 +6,9 @@ RUN mkdir /app
 WORKDIR /app
 
 COPY go.mod go.sum ./
-RUN go mod download -x
+RUN --mount=type=cache,target=/go/pkg/mod go mod download -x
 COPY . .
-RUN --mount=type=cache,target=/root/.cache/go-build \
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
   BIN_BUILD_FLAGS="CGO_ENABLED=0 GOOS=linux" make build-neard
 
 FROM alpine

--- a/cmd/packerd/Dockerfile
+++ b/cmd/packerd/Dockerfile
@@ -6,9 +6,9 @@ RUN mkdir /app
 WORKDIR /app
 
 COPY go.mod go.sum ./
-RUN go mod download -x
+RUN --mount=type=cache,target=/go/pkg/mod go mod download -x
 COPY . .
-RUN --mount=type=cache,target=/root/.cache/go-build \
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
   BIN_BUILD_FLAGS="CGO_ENABLED=0 GOOS=linux" make build-packerd
 
 FROM alpine

--- a/cmd/piecerd/Dockerfile
+++ b/cmd/piecerd/Dockerfile
@@ -6,9 +6,9 @@ RUN mkdir /app
 WORKDIR /app
 
 COPY go.mod go.sum ./
-RUN go mod download -x
+RUN --mount=type=cache,target=/go/pkg/mod go mod download -x
 COPY . .
-RUN --mount=type=cache,target=/root/.cache/go-build \
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
   BIN_BUILD_FLAGS="CGO_ENABLED=0 GOOS=linux" make build-piecerd
 
 FROM alpine

--- a/cmd/storaged/Dockerfile
+++ b/cmd/storaged/Dockerfile
@@ -6,9 +6,9 @@ RUN mkdir /app
 WORKDIR /app
 
 COPY go.mod go.sum ./
-RUN go mod download -x
+RUN --mount=type=cache,target=/go/pkg/mod go mod download -x
 COPY . .
-RUN --mount=type=cache,target=/root/.cache/go-build \
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
   BIN_BUILD_FLAGS="CGO_ENABLED=0 GOOS=linux" make build-storaged
 
 FROM alpine


### PR DESCRIPTION
Current code uses go build cache and saves a lot of time, but it still downloads all dependencies when even a single line of go.mod or go.sum changes, which is a big waste of CPU cycles and network traffic. This PR caches go modules too.