### PR TITLE
show storage request status as text in JSON [shipit]

### DIFF
--- a/cmd/storaged/storage/brokerstorage/brokerstorage.go
+++ b/cmd/storaged/storage/brokerstorage/brokerstorage.go
@@ -395,6 +395,8 @@ func storageRequestStatusToStorageRequestStatus(status broker.StorageRequestStat
 		return storage.StatusDealMaking, nil
 	case broker.RequestSuccess:
 		return storage.StatusSuccess, nil
+	case broker.RequestError:
+		return storage.StatusError, nil
 	default:
 		return storage.StatusUnknown, fmt.Errorf("unknown status: %s", status)
 	}

--- a/cmd/storaged/storage/storage.go
+++ b/cmd/storaged/storage/storage.go
@@ -20,23 +20,25 @@ type Requester interface {
 }
 
 // Status is the status of a StorageRequest.
-type Status int
+type Status string
 
 const (
 	// StatusUnknown is the default value to an unitialized
 	// StorageRequest. This status must be considered invalid in any
 	// real StorageRequest instance.
-	StatusUnknown Status = iota
+	StatusUnknown Status = "Unknown"
 	// StatusBatching indicates that the storage request is being batched.
-	StatusBatching
+	StatusBatching Status = "Batching"
 	// StatusPreparing indicates that the batch containing the data is being prepared.
-	StatusPreparing
+	StatusPreparing Status = "Preparing"
 	// StatusAuctioning indicates that the batch containing the data is being auctioned.
-	StatusAuctioning
+	StatusAuctioning Status = "Auctioning"
 	// StatusDealMaking indicates that the data is in deal-making process.
-	StatusDealMaking
+	StatusDealMaking Status = "DealMaking"
 	// StatusSuccess indicates that the request was stored in Filecoin.
-	StatusSuccess
+	StatusSuccess Status = "Success"
+	// StatusError indicates that there is some error handling the request.
+	StatusError Status = "Error"
 )
 
 // Request is a request for storing data in a Broker.


### PR DESCRIPTION
The only thing this PR does is to turn the response from 
```
{"request":{"id":"01fbw423pnpy72kbvdc70pqzwn","cid":{"/":"QmfVNHKPhP7aMVVtAA6EZFryHS68KkjdYgJmwn3qQVUQ8R"},"status_code":1},"deals":null}
```
to 
```
{"request":{"id":"01fbw423pnpy72kbvdc70pqzwn","cid":{"/":"QmfVNHKPhP7aMVVtAA6EZFryHS68KkjdYgJmwn3qQVUQ8R"},"status_code":"Batching"},"deals":null}
```
which looks more intuitive to developers.