### PR TITLE
packer: label open and done batches per origin

### DIFF
--- a/cmd/packerd/packer/packer_test.go
+++ b/cmd/packerd/packer/packer_test.go
@@ -201,7 +201,7 @@ func TestStats(t *testing.T) {
 	ctx := context.Background()
 
 	packer, _, _ := createPacker(t)
-	_, err := packer.store.GetStats(ctx)
+	_, _, err := packer.store.GetStats(ctx)
 	require.NoError(t, err)
 }
 

--- a/cmd/packerd/store/queries/batches.sql
+++ b/cmd/packerd/store/queries/batches.sql
@@ -38,16 +38,20 @@ RETURNING batch_id, total_size, origin;
 -- name: GetStorageRequestsFromBatch :many
 SELECT * FROM storage_requests where batch_id=$1;
 
--- name: OpenBatchStats :one
-SELECT count(*) as batches_cid_count,
-       (COALESCE(sum(sr.size),0))::bigint as batches_bytes,
+-- name: OpenBatchStats :many
+SELECT b.origin, 
+       count(*) as cid_count,
+       (COALESCE(sum(sr.size),0))::bigint as bytes,
        count(DISTINCT sr.batch_id) batches_count
 FROM storage_requests sr
 JOIN batches b ON b.batch_id=sr.batch_id
-WHERE b.status='open';
+WHERE b.status='open'
+group by b.origin;
 
--- name: DoneBatchStats :one
-SELECT COUNT(*) as batches_count,
-       (COALESCE(sum(total_size),0))::bigint as batches_bytes
+-- name: DoneBatchStats :many
+SELECT origin,
+       COUNT(*) as batches_count,
+       (COALESCE(sum(total_size),0))::bigint as bytes
 FROM batches
-where status='done';
+where status='done'
+group by origin;


### PR DESCRIPTION
This PR will label some metrics in packer per origin, so we can show a bit more detailed info around open batches per origin.
I'll do the Grafana part later when deployed.