### PR TITLE
mod: update bidbot so can have fix for handling os signals

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/viper v1.8.1
 	github.com/stretchr/testify v1.7.0
-	github.com/textileio/bidbot v0.0.5-0.20210802202026-1d12f4bc3d47
+	github.com/textileio/bidbot v0.0.5-0.20210812152825-8b6499ad10ca
 	github.com/textileio/go-datastore-extensions v1.0.1
 	github.com/textileio/go-ds-badger3 v0.0.0-20210324034212-7b7fb3be3d1c
 	github.com/textileio/go-libp2p-pubsub-rpc v0.0.2

--- a/go.sum
+++ b/go.sum
@@ -2057,8 +2057,8 @@ github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpP
 github.com/syndtr/goleveldb v1.0.1-0.20210305035536-64b5b1c73954 h1:xQdMZ1WLrgkkvOZ/LDQxjVxMLdby7osSh4ZEVa5sIjs=
 github.com/syndtr/goleveldb v1.0.1-0.20210305035536-64b5b1c73954/go.mod h1:u2MKkTVTVJWe5D1rCvame8WqhBd88EuIwODJZ1VHCPM=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
-github.com/textileio/bidbot v0.0.5-0.20210802202026-1d12f4bc3d47 h1:phpYe9CC0ZKv+E1FKzbzYGFNZg2iYeJfY+YdSyEY/bM=
-github.com/textileio/bidbot v0.0.5-0.20210802202026-1d12f4bc3d47/go.mod h1:zv9Pum5JmcPBN2HkcMiqXds0qWP4znLvBmr8NFrSvsc=
+github.com/textileio/bidbot v0.0.5-0.20210812152825-8b6499ad10ca h1:DOYHIfRsMa9Dreh7VTeEhLKoFesVPcw1LnlBKsV8sI4=
+github.com/textileio/bidbot v0.0.5-0.20210812152825-8b6499ad10ca/go.mod h1:zv9Pum5JmcPBN2HkcMiqXds0qWP4znLvBmr8NFrSvsc=
 github.com/textileio/go-datastore-extensions v1.0.1 h1:qIJGqJaigQ1wD4TdwS/hf73u0HChhXvvUSJuxBEKS+c=
 github.com/textileio/go-datastore-extensions v1.0.1/go.mod h1:Pzj9FDRkb55910dr/FX8M7WywvnS26gBgEDez1ZBuLE=
 github.com/textileio/go-ds-badger3 v0.0.0-20210324034212-7b7fb3be3d1c h1:iOWa9/AXFssCi7VhbEvVkpCYXqq/n3E2zKH6u+9pIfM=


### PR DESCRIPTION
Updating `bidbot` to include [this](https://github.com/textileio/bidbot/pull/30) fix.
This wasn't allowing _all_ daemons to have proper graceful termination, which resulted in jobs getting stuck since executing one were not waited before closing due to a forced kill.