### PR TITLE
print the string representation of the filclient exitcode

### DIFF
--- a/cmd/dealerd/dealer/filclient/filclient.go
+++ b/cmd/dealerd/dealer/filclient/filclient.go
@@ -185,7 +185,7 @@ func (fc *FilClient) ResolveDealIDFromMessage(
 	}
 
 	if mlookup.Receipt.ExitCode != 0 {
-		return 0, fmt.Errorf("the message failed to execute (exit: %d)", mlookup.Receipt.ExitCode)
+		return 0, fmt.Errorf("the message failed to execute (exit: %s)", mlookup.Receipt.ExitCode)
 	}
 
 	var retval market.PublishStorageDealsReturn


### PR DESCRIPTION
We can seem something from the dealerd log
```
trying to resolve deal-id from message bafy2bzaceckocgpd36zlgnmsgqlder7wa3pr3t5cwemw5z2wptrsmwne5ztg6: the message failed to execute (exit: 16)
```
16 is actually `ErrIllegalArgument`, also `FirstActorErrorCode`.