### PR TITLE
do not fail simply because the error cause changes

### DIFF
--- a/cmd/brokerd/store/store.go
+++ b/cmd/brokerd/store/store.go
@@ -292,9 +292,6 @@ func (s *Store) BatchError(
 				return fmt.Errorf("error cause should be empty: %s", sd.Error)
 			}
 		case broker.BatchStatusError:
-			if sd.Error != errorCause {
-				return fmt.Errorf("the error cause is different from the registered on : %s %s", sd.Error, errorCause)
-			}
 			brIDs, err = txn.GetStorageRequestIDs(ctx, batchIDToSQL(id))
 			return err
 		default:


### PR DESCRIPTION
Frequently saw such errors https://cloudlogging.app.goo.gl/vVS47e6bLoYGSLmZ8
> calling finalized-deal handler: processing finalized deal: moving batch to error status: the error cause is different from the registered on : selecting winners: insufficient bids re-auction deadline 1037240 is greater than batch deadline  1025124: auction deadline exceeded

> calling finalized-deal handler: processing finalized deal: moving batch to error status: the error cause is different from the registered on : re-auction deadline 1027204 is greater than batch deadline  1024322: auction deadline exceeded re-auction deadline 1037241 is greater than batch deadline  1024322: auction deadline exceeded

It makes no sense to fail a message handler simply because the error cause differs from what happened last time for the batch, esp. now that the error cause of each auction is saved to `apid` too.