### PR TITLE
remove auction concurrency to smooth auctions

### DIFF
--- a/cmd/auctioneerd/auctioneer/queue/queue.go
+++ b/cmd/auctioneerd/auctioneer/queue/queue.go
@@ -38,7 +38,7 @@ var (
 	StartDelay = time.Second * 10
 
 	// MaxConcurrency is the maximum number of auctions that will be handled concurrently.
-	MaxConcurrency = 100
+	MaxConcurrency = 1
 
 	// ErrAuctionNotFound indicates the requested auction was not found.
 	ErrAuctionNotFound = errors.New("auction not found")


### PR DESCRIPTION
This is prob. the most straightforward way to avoid blustering miners. It only governs the bidding process but should prevent big bursts. Only as a temporary workaround.