### PR TITLE
use proper message broker ack timeout in auctioneerd

### DIFF
--- a/cmd/auctioneerd/auctioneer/auctioneer.go
+++ b/cmd/auctioneerd/auctioneer/auctioneer.go
@@ -40,8 +40,8 @@ var (
 	// maxAuctionDuration is the max duration an auction can run for.
 	maxAuctionDuration = time.Minute * 10
 
-	// notifyTimeout is the max duration the auctioneer will wait for a response from bidders.
-	notifyTimeout = time.Second * 30
+	// NotifyTimeout is the max duration the auctioneer will wait for a response from bidders.
+	NotifyTimeout = time.Second * 30
 
 	// ErrAuctionNotFound indicates the requested auction was not found.
 	ErrAuctionNotFound = errors.New("auction not found")
@@ -593,7 +593,7 @@ func (a *Auctioneer) publishWin(ctx context.Context, id core.ID, bid core.BidID,
 	if err != nil {
 		return fmt.Errorf("marshaling message: %v", err)
 	}
-	tctx, cancel := context.WithTimeout(ctx, notifyTimeout)
+	tctx, cancel := context.WithTimeout(ctx, NotifyTimeout)
 	defer cancel()
 	res, err := topic.Publish(tctx, msg)
 	if err != nil {
@@ -627,7 +627,7 @@ func (a *Auctioneer) publishProposal(
 	if err != nil {
 		return fmt.Errorf("marshaling message: %v", err)
 	}
-	tctx, cancel := context.WithTimeout(ctx, notifyTimeout)
+	tctx, cancel := context.WithTimeout(ctx, NotifyTimeout)
 	defer cancel()
 	res, err := topic.Publish(tctx, msg, rpc.WithRepublishing(true))
 	if err != nil {

--- a/cmd/auctioneerd/service/service.go
+++ b/cmd/auctioneerd/service/service.go
@@ -63,7 +63,8 @@ func New(conf Config, mb mbroker.MsgBroker, fc filclient.FilClient) (*Service, e
 		finalizer: fin,
 	}
 
-	if err := mbroker.RegisterHandlers(mb, s); err != nil {
+	// OnDealProposalAccepted needs to notify bidbot about the proposal which requires NotifyTimeout. 2x to be safe.
+	if err := mbroker.RegisterHandlers(mb, s, mbroker.WithACKDeadline(auctioneer.NotifyTimeout*2)); err != nil {
 		return nil, fmt.Errorf("registering msgbroker handlers: %s", err)
 	}
 


### PR DESCRIPTION
Noticed below errors which is the result of the context being expired too early.

```
{"severity":"error","ts":"2021-08-27T02:45:07.322Z","logger":"auctioneer","caller":"auctioneer/auctioneer.go:225","msg":"saving proposal cid: context deadline exceeded"}
```