### PR TITLE
adjust net.core.rmem_max for quic

### DIFF
--- a/k8/base/auctioneerd.yaml
+++ b/k8/base/auctioneerd.yaml
@@ -19,6 +19,9 @@ spec:
         runAsUser: 1000
         runAsGroup: 2000
         fsGroup: 2000
+        sysctls:
+          - name: net.core.rmem_max
+            value: "2097152"
       serviceAccountName: postgres-cloud-sql
       terminationGracePeriodSeconds: 10
       initContainers:


### PR DESCRIPTION
Just to get rid of a warning in logs https://github.com/textileio/broker-core/pull/new/merlin/rmem_max-for-quic

> 2021/09/10 20:16:50 failed to sufficiently increase receive buffer size (was: 208 kiB, wanted: 2048 kiB, got: 416 kiB). See https://github.com/lucas-clemente/quic-go/wiki/UDP-Receive-Buffer-Size for details.