### PR TITLE
filclient: specify NetStruct to be wired in api

### DIFF
--- a/cmd/dealerd/dealer/filclient/filclient_test.go
+++ b/cmd/dealerd/dealer/filclient/filclient_test.go
@@ -154,9 +154,9 @@ func TestCheckStatusWithStorageProvider(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 
-	proposalCid, err := cid.Decode("bafyreibru2chqj7wanixo6m5qnmamovvgby7672ws3yojzyttimu7fl72q")
+	proposalCid, err := cid.Decode("bafyreieakjjn6kv36zfo23e67mvn2mrjgjz34w2awjaivskfhf4okjhdva")
 	require.NoError(t, err)
-	status, err := client.CheckDealStatusWithStorageProvider(ctx, "f01278", proposalCid)
+	status, err := client.CheckDealStatusWithStorageProvider(ctx, "f0840770", proposalCid)
 	require.NoError(t, err)
 	fmt.Printf("%s\n", logging.MustJSONIndent(status))
 	fmt.Printf("%s\n", storagemarket.DealStatesDescriptions[status.State])
@@ -179,6 +179,7 @@ func createFilClient(t *testing.T) *v0api.FullNodeStruct {
 	closer, err := jsonrpc.NewMergeClient(context.Background(), "https://api.node.glif.io", "Filecoin",
 		[]interface{}{
 			&api.CommonStruct.Internal,
+			&api.NetStruct.Internal,
 			&api.Internal,
 		},
 		http.Header{},

--- a/cmd/dealerd/service/service.go
+++ b/cmd/dealerd/service/service.go
@@ -79,6 +79,7 @@ func New(mb mbroker.MsgBroker, conf Config) (*Service, error) {
 		closer, err := jsonrpc.NewMergeClient(context.Background(), conf.LotusGatewayURL, "Filecoin",
 			[]interface{}{
 				&lotusAPI.CommonStruct.Internal,
+				&lotusAPI.NetStruct.Internal,
 				&lotusAPI.Internal,
 			},
 			http.Header{},

--- a/go.mod
+++ b/go.mod
@@ -9,20 +9,16 @@ require (
 	github.com/deckarep/golang-set v1.7.1 // indirect
 	github.com/dustin/go-humanize v1.0.0
 	github.com/ethereum/go-ethereum v1.10.8
-	github.com/filecoin-project/dagstore v0.4.3 // indirect
 	github.com/filecoin-project/go-address v0.0.6
 	github.com/filecoin-project/go-cbor-util v0.0.0-20191219014500-08c40a1e63a2
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
-	github.com/filecoin-project/go-data-transfer v1.7.8 // indirect
 	github.com/filecoin-project/go-fil-commcid v0.1.0
 	github.com/filecoin-project/go-fil-commp-hashhash v0.1.0
 	github.com/filecoin-project/go-fil-markets v1.8.1
 	github.com/filecoin-project/go-jsonrpc v0.1.4-0.20210217175800-45ea43ac2bec
 	github.com/filecoin-project/go-state-types v0.1.1-0.20210810190654-139e0e79e69e
-	github.com/filecoin-project/go-statemachine v1.0.1 // indirect
-	github.com/filecoin-project/lotus v1.11.0
+	github.com/filecoin-project/lotus v1.11.2
 	github.com/filecoin-project/specs-actors v0.9.14
-	github.com/filecoin-project/specs-actors/v5 v5.0.4 // indirect
 	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/golang-migrate/migrate/v4 v4.14.1
@@ -37,7 +33,6 @@ require (
 	github.com/ipfs/go-unixfs v0.2.6
 	github.com/ipfs/interface-go-ipfs-core v0.4.0
 	github.com/ipld/go-car v0.1.1-0.20201119040415-11b6074b6d4d
-	github.com/ipld/go-car/v2 v2.0.3-0.20210811121346-c514a30114d7 // indirect
 	github.com/jackc/pgconn v1.10.0
 	github.com/jackc/pgx/v4 v4.12.0
 	github.com/joho/godotenv v1.3.0
@@ -47,7 +42,6 @@ require (
 	github.com/libp2p/go-libp2p-circuit v0.4.0
 	github.com/libp2p/go-libp2p-connmgr v0.2.4
 	github.com/libp2p/go-libp2p-core v0.8.6
-	github.com/libp2p/go-libp2p-pubsub v0.5.4 // indirect
 	github.com/libp2p/go-libp2p-swarm v0.5.3
 	github.com/mr-tron/base58 v1.2.0
 	github.com/multiformats/go-multiaddr v0.3.3

--- a/go.sum
+++ b/go.sum
@@ -423,7 +423,6 @@ github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0/go.mod h1:WTuJWgBQY0o
 github.com/filecoin-project/go-data-transfer v1.0.1/go.mod h1:UxvfUAY9v3ub0a21BSK9u3pB2aq30Y0KMsG+w9/ysyo=
 github.com/filecoin-project/go-data-transfer v1.2.7/go.mod h1:mvjZ+C3NkBX10JP4JMu27DCjUouHFjHwUGh+Xc4yvDA=
 github.com/filecoin-project/go-data-transfer v1.4.3/go.mod h1:n8kbDQXWrY1c4UgfMa9KERxNCWbOTDwdNhf2MpN9dpo=
-github.com/filecoin-project/go-data-transfer v1.6.0/go.mod h1:E3WW4mCEYwU2y65swPEajSZoFWFmfXt7uwGduoACZQc=
 github.com/filecoin-project/go-data-transfer v1.7.6/go.mod h1:Cbl9lzKOuAyyIxp1tE+VbV5Aix4bxzA7uJGA9wGM4fM=
 github.com/filecoin-project/go-data-transfer v1.7.8 h1:s4cF9nX9sEy7RgZd3NW92YN/hKyIy2fQl+7dVOAS8r8=
 github.com/filecoin-project/go-data-transfer v1.7.8/go.mod h1:Cbl9lzKOuAyyIxp1tE+VbV5Aix4bxzA7uJGA9wGM4fM=
@@ -438,7 +437,6 @@ github.com/filecoin-project/go-fil-commp-hashhash v0.1.0/go.mod h1:73S8WSEWh9vr0
 github.com/filecoin-project/go-fil-markets v1.0.5-0.20201113164554-c5eba40d5335/go.mod h1:AJySOJC00JRWEZzRG2KsfUnqEf5ITXxeX09BE9N4f9c=
 github.com/filecoin-project/go-fil-markets v1.1.9/go.mod h1:0yQu5gvrjFoAIyzPSSJ+xUdCG83vjInAFbTswIB5/hk=
 github.com/filecoin-project/go-fil-markets v1.2.5/go.mod h1:7JIqNBmFvOyBzk/EiPYnweVdQnWhshixb5B9b1653Ag=
-github.com/filecoin-project/go-fil-markets v1.5.0/go.mod h1:7be6zzFwaN8kxVeYZf/UUj/JilHC0ogPvWqE1TW8Ptk=
 github.com/filecoin-project/go-fil-markets v1.8.1 h1:nNJB5EIp5c6yo/z51DloVaL7T24SslCoxSDOXwNQr9k=
 github.com/filecoin-project/go-fil-markets v1.8.1/go.mod h1:PIPyOhoDLWT5NcciJQeK6Hes7MIeczGLNWVO/2Vy0a4=
 github.com/filecoin-project/go-hamt-ipld v0.1.5 h1:uoXrKbCQZ49OHpsTCkrThPNelC4W3LPEk0OrS/ytIBM=
@@ -475,8 +473,8 @@ github.com/filecoin-project/go-statestore v0.1.1/go.mod h1:LFc9hD+fRxPqiHiaqUEZO
 github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b/go.mod h1:Q0GQOBtKf1oE10eSXSlhN45kDBdGvEcVOqMiffqX+N8=
 github.com/filecoin-project/lotus v1.8.0/go.mod h1:a4vfqKJ2ynqg5TXpcPer/orWZIKBwJAv5TsBUj1PrSQ=
 github.com/filecoin-project/lotus v1.10.0/go.mod h1:GjqPFYGMIy4x+2FLA6m8Oa2+21sqewHRPZv9TcAgHaU=
-github.com/filecoin-project/lotus v1.11.0 h1:xaJkq65E4TJKk0qXdDhW7w7KD/bVRaAtm/rWu69AhFQ=
-github.com/filecoin-project/lotus v1.11.0/go.mod h1:V2+slhg/GRYb7m31ROOxJV2/zd+iQJ7FpH3xED1OUL4=
+github.com/filecoin-project/lotus v1.11.2 h1:DorhieA8MUIXFZNlU3j0eUK2L6RNEBt5T+4V//ssrFw=
+github.com/filecoin-project/lotus v1.11.2/go.mod h1:Ur2KuT1Iz5HF4Y1g6nFEaRpH3lFVQFfZzVHRaCfXiIc=
 github.com/filecoin-project/specs-actors v0.6.1/go.mod h1:dRdy3cURykh2R8O/DKqy8olScl70rmIS7GrB4hB1IDY=
 github.com/filecoin-project/specs-actors v0.9.4/go.mod h1:BStZQzx5x7TmCkLv0Bpa07U6cPKol6fd3w9KjMPZ6Z4=
 github.com/filecoin-project/specs-actors v0.9.12/go.mod h1:TS1AW/7LbG+615j4NsjMK1qlpAwaFsG9w0V2tg2gSao=
@@ -909,7 +907,6 @@ github.com/ipfs/go-graphsync v0.4.2/go.mod h1:/VmbZTUdUMTbNkgzAiCEucIIAU3BkLE2cZ
 github.com/ipfs/go-graphsync v0.4.3/go.mod h1:mPOwDYv128gf8gxPFgXnz4fNrSYPsWyqisJ7ych+XDY=
 github.com/ipfs/go-graphsync v0.5.2/go.mod h1:e2ZxnClqBBYAtd901g9vXMJzS47labjAtOzsWtOzKNk=
 github.com/ipfs/go-graphsync v0.6.0/go.mod h1:e2ZxnClqBBYAtd901g9vXMJzS47labjAtOzsWtOzKNk=
-github.com/ipfs/go-graphsync v0.6.1/go.mod h1:e2ZxnClqBBYAtd901g9vXMJzS47labjAtOzsWtOzKNk=
 github.com/ipfs/go-graphsync v0.6.8/go.mod h1:GdHT8JeuIZ0R4lSjFR16Oe4zPi5dXwKi9zR9ADVlcdk=
 github.com/ipfs/go-graphsync v0.6.9 h1:I15gVcZuqsaeaj64/SjlwiIAc9MkOgfSv0M1CgcoFRE=
 github.com/ipfs/go-graphsync v0.6.9/go.mod h1:GdHT8JeuIZ0R4lSjFR16Oe4zPi5dXwKi9zR9ADVlcdk=


### PR DESCRIPTION
Fix a missed wiring in Lotus v1.11.0 -> v1.11.2 transition. which makes `NetFindPeerID` fail.

This is exactly the cause of this other problem: https://github.com/textileio/bidbot/pull/48, since `ID` is also in the `Net` struct.
Probably, we should do this same wiring in `bidbot`. (If we want to revert again to `ID()` is optional; but at least to not let other `Net` related APIs fail).