### PR TITLE
cancel ongoing CI actions on the same branch [shipit]

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,9 @@
 name: Deploy
 
+concurrency:
+  group: deploy-${{github.ref}}
+  cancel-in-progress: true
+
 on:
   push:
     branches:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -4,6 +4,11 @@ on:
     branches:
       - main
   pull_request:
+
+concurrency:
+  group: review-${{github.ref}}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,15 @@
+name: Test
+
 on:
   push:
     branches:
       - main
   pull_request:
-name: Test
+
+concurrency:
+  group: test-${{github.ref}}
+  cancel-in-progress: true
+
 jobs:
   test:
     strategy:


### PR DESCRIPTION
When more than one PRs are merged in a short burst, they may race to deploy themselves, and there's a chance that an earlier deployment action runs slower than the latest one, hence deploying an undesired commit to production (or even worse, cause SQL migration issues). Credits to Ignacio for precaution on this.

As a side benefit, can save some CI time if we add some fix and push again right after pushing to a branch.

See https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#example-using-concurrency-to-cancel-any-in-progress-job-or-run

Verified that it can cancel a previous deployment.
<img width="927" alt="image" src="https://user-images.githubusercontent.com/1369696/134983287-93e4d158-50a9-4c1c-8a87-9c7ca2be8b5e.png">