### PR TITLE
postgres: avoid pods racing with cloudsql proxy warmup

### DIFF
--- a/bin/with-postgres.sh
+++ b/bin/with-postgres.sh
@@ -18,6 +18,7 @@ DB_USER=${DAEMON}
 POSTGRES_PASSWORD=$(echo -n $POSTGRES_PASSWORD | tr -d \\n)
 DB_PASSWORD=$(echo -n $DB_PASSWORD | tr -d \\n)
 
+sleep 5
 # when starting the pod, connect to postgres with admin privilege, create user
 # and schema if not exist, and force change password, then starts daemon with
 # the correct postgres URI. The use is restricted to the schema with the same name.


### PR DESCRIPTION
Get rid of these restart counts that will become annoying when we have restart pod alerts since they add noise. It's never entirely trival to know if those restarts are from this problem, or real crashes.
![image](https://user-images.githubusercontent.com/6136245/135497480-9808f13c-1dd5-4dac-b376-425936d68d5e.png)

Looking at the logs:
```
...
+ '[' 2 -eq 0 ]
+ quit 'fail to initialize postgres database'
+ echo 'fail to initialize postgres database'
+ exit 1
fail to initialize postgres database
```

We should target to always see a 0-value in the `RESTARTS` column. If that isn't the case, then we can have a clear signal to investigate.