### PR TITLE
storaged/auction-data.sh: fix jq array generation

### DIFF
--- a/cmd/storaged/auction-data.sh
+++ b/cmd/storaged/auction-data.sh
@@ -37,7 +37,7 @@ if [ ! -z "$PROVIDERS" ]; then
 	PROVIDER_IDS=($(echo "$PROVIDERS" | tr ',' '\n'))
 
 	PROVIDERS_TEMPLATE=',"providers":%s'
-	PROVIDERS_JSON=$(printf "$PROVIDERS_TEMPLATE" "$(jq --compact-output --null-input '$ARGS.positional' --args \"${PROVIDER_IDS[@]})\"")
+	PROVIDERS_JSON=$(printf "$PROVIDERS_TEMPLATE" "$(jq --compact-output --null-input '$ARGS.positional' --args ${PROVIDER_IDS[@]})")
 fi
 
 JSON_TEMPLATE='{"payloadCid":"%s","pieceCid":"%s","pieceSize":%s, "repFactor":%s, "deadline":"%s", "carURL":{"url":"%s"} %s %s}\n'


### PR DESCRIPTION
Fixing some extra quoting in the script that breaks the generated JSON.