### PR TITLE
reflect problems of providers more quickly

### DIFF
--- a/cmd/apid/store/migrations/migrations.go
+++ b/cmd/apid/store/migrations/migrations.go
@@ -94,7 +94,7 @@ func _001_initDownSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "001_init.down.sql", size: 64, mode: os.FileMode(436), modTime: time.Unix(1628867589, 0)}
+	info := bindataFileInfo{name: "001_init.down.sql", size: 64, mode: os.FileMode(420), modTime: time.Unix(1630721178, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -114,7 +114,7 @@ func _001_initUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "001_init.up.sql", size: 1041, mode: os.FileMode(436), modTime: time.Unix(1630327856, 0)}
+	info := bindataFileInfo{name: "001_init.up.sql", size: 1041, mode: os.FileMode(420), modTime: time.Unix(1630721178, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/cmd/auctioneerd/auctioneer/auctioneer.go
+++ b/cmd/auctioneerd/auctioneer/auctioneer.go
@@ -228,7 +228,7 @@ func (a *Auctioneer) DeliverProposal(ctx context.Context, auctionID core.ID, bid
 // MarkFinalizedDeal marks the deal as confirmed if it has no error.
 func (a *Auctioneer) MarkFinalizedDeal(ctx context.Context, fad broker.FinalizedDeal) error {
 	if fad.ErrorCause != "" {
-		return nil
+		return a.queue.MarkDealAsFailed(ctx, fad.AuctionID, fad.BidID)
 	}
 	return a.queue.MarkDealAsConfirmed(ctx, fad.AuctionID, fad.BidID)
 }

--- a/cmd/auctioneerd/auctioneer/queue/internal/db/db.go
+++ b/cmd/auctioneerd/auctioneer/queue/internal/db/db.go
@@ -64,6 +64,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.updateDealConfirmedAtStmt, err = db.PrepareContext(ctx, updateDealConfirmedAt); err != nil {
 		return nil, fmt.Errorf("error preparing query UpdateDealConfirmedAt: %w", err)
 	}
+	if q.updateDealFailedAtStmt, err = db.PrepareContext(ctx, updateDealFailedAt); err != nil {
+		return nil, fmt.Errorf("error preparing query UpdateDealFailedAt: %w", err)
+	}
 	if q.updateProposalCidStmt, err = db.PrepareContext(ctx, updateProposalCid); err != nil {
 		return nil, fmt.Errorf("error preparing query UpdateProposalCid: %w", err)
 	}
@@ -148,6 +151,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing updateDealConfirmedAtStmt: %w", cerr)
 		}
 	}
+	if q.updateDealFailedAtStmt != nil {
+		if cerr := q.updateDealFailedAtStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing updateDealFailedAtStmt: %w", cerr)
+		}
+	}
 	if q.updateProposalCidStmt != nil {
 		if cerr := q.updateProposalCidStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing updateProposalCidStmt: %w", cerr)
@@ -216,6 +224,7 @@ type Queries struct {
 	setStorageProviderUnhealthyStmt    *sql.Stmt
 	updateAuctionStatusAndErrorStmt    *sql.Stmt
 	updateDealConfirmedAtStmt          *sql.Stmt
+	updateDealFailedAtStmt             *sql.Stmt
 	updateProposalCidStmt              *sql.Stmt
 	updateProposalCidDeliveryErrorStmt *sql.Stmt
 	updateWinningBidStmt               *sql.Stmt
@@ -239,6 +248,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		setStorageProviderUnhealthyStmt:    q.setStorageProviderUnhealthyStmt,
 		updateAuctionStatusAndErrorStmt:    q.updateAuctionStatusAndErrorStmt,
 		updateDealConfirmedAtStmt:          q.updateDealConfirmedAtStmt,
+		updateDealFailedAtStmt:             q.updateDealFailedAtStmt,
 		updateProposalCidStmt:              q.updateProposalCidStmt,
 		updateProposalCidDeliveryErrorStmt: q.updateProposalCidDeliveryErrorStmt,
 		updateWinningBidStmt:               q.updateWinningBidStmt,

--- a/cmd/auctioneerd/auctioneer/queue/internal/db/models.go
+++ b/cmd/auctioneerd/auctioneer/queue/internal/db/models.go
@@ -73,6 +73,7 @@ type Bid struct {
 	ProposalCidDeliveryError sql.NullString `json:"proposalCidDeliveryError"`
 	DealConfirmedAt          sql.NullTime   `json:"dealConfirmedAt"`
 	WonReason                sql.NullString `json:"wonReason"`
+	DealFailedAt             sql.NullTime   `json:"dealFailedAt"`
 }
 
 type BidEvent struct {

--- a/cmd/auctioneerd/auctioneer/queue/migrations/007_bids_add_deal_failed_at.down.sql
+++ b/cmd/auctioneerd/auctioneer/queue/migrations/007_bids_add_deal_failed_at.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE bids DROP COLUMN deal_failed_at;
+

--- a/cmd/auctioneerd/auctioneer/queue/migrations/007_bids_add_deal_failed_at.up.sql
+++ b/cmd/auctioneerd/auctioneer/queue/migrations/007_bids_add_deal_failed_at.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE bids ADD COLUMN deal_failed_at TIMESTAMP;
+

--- a/cmd/auctioneerd/auctioneer/queue/migrations/migrations.go
+++ b/cmd/auctioneerd/auctioneer/queue/migrations/migrations.go
@@ -13,6 +13,8 @@
 // migrations/005_auctions_add_providers.up.sql
 // migrations/006_consume_bidbot_events.down.sql
 // migrations/006_consume_bidbot_events.up.sql
+// migrations/007_bids_add_deal_failed_at.down.sql
+// migrations/007_bids_add_deal_failed_at.up.sql
 package migrations
 
 import (
@@ -104,7 +106,7 @@ func _001_initDownSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "001_init.down.sql", size: 38, mode: os.FileMode(436), modTime: time.Unix(1630327856, 0)}
+	info := bindataFileInfo{name: "001_init.down.sql", size: 38, mode: os.FileMode(420), modTime: time.Unix(1630721178, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -124,7 +126,7 @@ func _001_initUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "001_init.up.sql", size: 1526, mode: os.FileMode(436), modTime: time.Unix(1630327856, 0)}
+	info := bindataFileInfo{name: "001_init.up.sql", size: 1526, mode: os.FileMode(420), modTime: time.Unix(1630721178, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -144,7 +146,7 @@ func _002_bids_support_calculating_ratesDownSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "002_bids_support_calculating_rates.down.sql", size: 87, mode: os.FileMode(436), modTime: time.Unix(1633021059, 0)}
+	info := bindataFileInfo{name: "002_bids_support_calculating_rates.down.sql", size: 87, mode: os.FileMode(420), modTime: time.Unix(1632405209, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -164,7 +166,7 @@ func _002_bids_support_calculating_ratesUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "002_bids_support_calculating_rates.up.sql", size: 123, mode: os.FileMode(436), modTime: time.Unix(1631615050, 0)}
+	info := bindataFileInfo{name: "002_bids_support_calculating_rates.up.sql", size: 123, mode: os.FileMode(420), modTime: time.Unix(1631305441, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -184,7 +186,7 @@ func _003_auctions_add_client_addressDownSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "003_auctions_add_client_address.down.sql", size: 49, mode: os.FileMode(436), modTime: time.Unix(1633021059, 0)}
+	info := bindataFileInfo{name: "003_auctions_add_client_address.down.sql", size: 49, mode: os.FileMode(420), modTime: time.Unix(1632405209, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -204,7 +206,7 @@ func _003_auctions_add_client_addressUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "003_auctions_add_client_address.up.sql", size: 213, mode: os.FileMode(436), modTime: time.Unix(1633021059, 0)}
+	info := bindataFileInfo{name: "003_auctions_add_client_address.up.sql", size: 213, mode: os.FileMode(420), modTime: time.Unix(1632405209, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -224,7 +226,7 @@ func _004_bids_add_won_reasonDownSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "004_bids_add_won_reason.down.sql", size: 42, mode: os.FileMode(436), modTime: time.Unix(1633021059, 0)}
+	info := bindataFileInfo{name: "004_bids_add_won_reason.down.sql", size: 42, mode: os.FileMode(420), modTime: time.Unix(1632936921, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -244,7 +246,7 @@ func _004_bids_add_won_reasonUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "004_bids_add_won_reason.up.sql", size: 45, mode: os.FileMode(436), modTime: time.Unix(1633021059, 0)}
+	info := bindataFileInfo{name: "004_bids_add_won_reason.up.sql", size: 45, mode: os.FileMode(420), modTime: time.Unix(1632936921, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -264,7 +266,7 @@ func _005_auctions_add_providersDownSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "005_auctions_add_providers.down.sql", size: 44, mode: os.FileMode(436), modTime: time.Unix(1633453830, 0)}
+	info := bindataFileInfo{name: "005_auctions_add_providers.down.sql", size: 44, mode: os.FileMode(420), modTime: time.Unix(1633536236, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -284,7 +286,7 @@ func _005_auctions_add_providersUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "005_auctions_add_providers.up.sql", size: 50, mode: os.FileMode(436), modTime: time.Unix(1633453830, 0)}
+	info := bindataFileInfo{name: "005_auctions_add_providers.up.sql", size: 50, mode: os.FileMode(420), modTime: time.Unix(1633536236, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -304,7 +306,7 @@ func _006_consume_bidbot_eventsDownSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "006_consume_bidbot_events.down.sql", size: 99, mode: os.FileMode(436), modTime: time.Unix(1633703350, 0)}
+	info := bindataFileInfo{name: "006_consume_bidbot_events.down.sql", size: 99, mode: os.FileMode(420), modTime: time.Unix(1633699314, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -324,7 +326,47 @@ func _006_consume_bidbot_eventsUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "006_consume_bidbot_events.up.sql", size: 914, mode: os.FileMode(436), modTime: time.Unix(1633703350, 0)}
+	info := bindataFileInfo{name: "006_consume_bidbot_events.up.sql", size: 914, mode: os.FileMode(420), modTime: time.Unix(1633699314, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var __007_bids_add_deal_failed_atDownSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\xf4\x09\x71\x0d\x52\x08\x71\x74\xf2\x71\x55\x48\xca\x4c\x29\x56\x70\x09\xf2\x0f\x50\x70\xf6\xf7\x09\xf5\xf5\x53\x48\x49\x4d\xcc\x89\x4f\x4b\xcc\xcc\x49\x4d\x89\x4f\x2c\xb1\xe6\xe2\x02\x04\x00\x00\xff\xff\x61\x34\xf9\x26\x2e\x00\x00\x00")
+
+func _007_bids_add_deal_failed_atDownSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__007_bids_add_deal_failed_atDownSql,
+		"007_bids_add_deal_failed_at.down.sql",
+	)
+}
+
+func _007_bids_add_deal_failed_atDownSql() (*asset, error) {
+	bytes, err := _007_bids_add_deal_failed_atDownSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "007_bids_add_deal_failed_at.down.sql", size: 46, mode: os.FileMode(420), modTime: time.Unix(1633704184, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var __007_bids_add_deal_failed_atUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\xf4\x09\x71\x0d\x52\x08\x71\x74\xf2\x71\x55\x48\xca\x4c\x29\x56\x70\x74\x71\x51\x70\xf6\xf7\x09\xf5\xf5\x53\x48\x49\x4d\xcc\x89\x4f\x4b\xcc\xcc\x49\x4d\x89\x4f\x2c\x51\x08\xf1\xf4\x75\x0d\x0e\x71\xf4\x0d\xb0\xe6\xe2\x02\x04\x00\x00\xff\xff\x43\xc8\x19\x2c\x37\x00\x00\x00")
+
+func _007_bids_add_deal_failed_atUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__007_bids_add_deal_failed_atUpSql,
+		"007_bids_add_deal_failed_at.up.sql",
+	)
+}
+
+func _007_bids_add_deal_failed_atUpSql() (*asset, error) {
+	bytes, err := _007_bids_add_deal_failed_atUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "007_bids_add_deal_failed_at.up.sql", size: 55, mode: os.FileMode(420), modTime: time.Unix(1633704184, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -393,6 +435,8 @@ var _bindata = map[string]func() (*asset, error){
 	"005_auctions_add_providers.up.sql":           _005_auctions_add_providersUpSql,
 	"006_consume_bidbot_events.down.sql":          _006_consume_bidbot_eventsDownSql,
 	"006_consume_bidbot_events.up.sql":            _006_consume_bidbot_eventsUpSql,
+	"007_bids_add_deal_failed_at.down.sql":        _007_bids_add_deal_failed_atDownSql,
+	"007_bids_add_deal_failed_at.up.sql":          _007_bids_add_deal_failed_atUpSql,
 }
 
 // AssetDir returns the file names below a certain
@@ -448,6 +492,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"005_auctions_add_providers.up.sql":           &bintree{_005_auctions_add_providersUpSql, map[string]*bintree{}},
 	"006_consume_bidbot_events.down.sql":          &bintree{_006_consume_bidbot_eventsDownSql, map[string]*bintree{}},
 	"006_consume_bidbot_events.up.sql":            &bintree{_006_consume_bidbot_eventsUpSql, map[string]*bintree{}},
+	"007_bids_add_deal_failed_at.down.sql":        &bintree{_007_bids_add_deal_failed_atDownSql, map[string]*bintree{}},
+	"007_bids_add_deal_failed_at.up.sql":          &bintree{_007_bids_add_deal_failed_atUpSql, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory

--- a/cmd/auctioneerd/auctioneer/queue/queries/bid.sql
+++ b/cmd/auctioneerd/auctioneer/queue/queries/bid.sql
@@ -32,14 +32,16 @@ WHERE auction_id = $1 and won_at IS NOT NULL;
 
 -- name: GetRecentWeekFailureRate :many
 -- here's the logic:
--- 1. take all winning bids happened in the recent week until 1 day ago (to exclude the deals waiting to be on-chain).
+-- 1. take all winning bids happened in the recent week until 1 day ago (to exclude the deals waiting to be on-chain), or
+-- if their deals failed.
 -- 2. calculate the freshness of each bid, ranging from 1 (1 week ago) to 7 (1 day ago).
 -- 3. sum up the failed bids (not be able to make a deal), weighed by their freshness, then divide by the number of wins.
 WITH b AS (SELECT storage_provider_id,
       extract(epoch from interval '1 weeks') / extract(epoch from current_timestamp - received_at) AS freshness,
       CASE WHEN deal_confirmed_at IS NULL THEN 1 ELSE 0 END failed
     FROM bids
-    WHERE received_at < current_timestamp - interval '1 days' AND received_at > current_timestamp - interval '1 weeks' AND won_at IS NOT NULL)
+    WHERE received_at > current_timestamp - interval '1 weeks' AND won_at IS NOT NULL
+    AND (deal_failed_at IS NOT NULL OR received_at < current_timestamp - interval '1 days'))
 SELECT b.storage_provider_id, (SUM(b.freshness*b.failed)*1000000/COUNT(*))::bigint AS failure_rate_ppm
 FROM b
 GROUP BY storage_provider_id;
@@ -83,4 +85,9 @@ WHERE id = $1 AND auction_id = $2;
 -- name: UpdateDealConfirmedAt :exec
 UPDATE bids
 SET deal_confirmed_at = CURRENT_TIMESTAMP
+WHERE id = $1 AND auction_id = $2;
+
+-- name: UpdateDealFailedAt :exec
+UPDATE bids
+SET deal_failed_at = CURRENT_TIMESTAMP
 WHERE id = $1 AND auction_id = $2;

--- a/cmd/auctioneerd/auctioneer/queue/queue.go
+++ b/cmd/auctioneerd/auctioneer/queue/queue.go
@@ -374,6 +374,17 @@ func (q *Queue) MarkDealAsConfirmed(
 	})
 }
 
+// MarkDealAsFailed marks the deal as failed by recording its failed time.
+func (q *Queue) MarkDealAsFailed(
+	ctx context.Context,
+	auctionID auction.ID,
+	bidID auction.BidID) error {
+	return q.db.UpdateDealFailedAt(ctx, db.UpdateDealFailedAtParams{
+		ID:        bidID,
+		AuctionID: auctionID,
+	})
+}
+
 // SaveStorageProvider saves the storage provider info.
 func (q *Queue) SaveStorageProvider(ctx context.Context, id string, version string, dealStartWindow uint64,
 	cidGravityConfigured, cidGravityStrict bool) error {

--- a/cmd/authd/store/migrations/migrations.go
+++ b/cmd/authd/store/migrations/migrations.go
@@ -94,7 +94,7 @@ func _001_initDownSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "001_init.down.sql", size: 24, mode: os.FileMode(436), modTime: time.Unix(1628018891, 0)}
+	info := bindataFileInfo{name: "001_init.down.sql", size: 24, mode: os.FileMode(420), modTime: time.Unix(1630721178, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -114,7 +114,7 @@ func _001_initUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "001_init.up.sql", size: 187, mode: os.FileMode(436), modTime: time.Unix(1628018891, 0)}
+	info := bindataFileInfo{name: "001_init.up.sql", size: 187, mode: os.FileMode(420), modTime: time.Unix(1630721178, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/cmd/brokerd/store/migrations/migrations.go
+++ b/cmd/brokerd/store/migrations/migrations.go
@@ -102,7 +102,7 @@ func _001_initDownSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "001_init.down.sql", size: 90, mode: os.FileMode(436), modTime: time.Unix(1628018891, 0)}
+	info := bindataFileInfo{name: "001_init.down.sql", size: 90, mode: os.FileMode(420), modTime: time.Unix(1630721178, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -122,7 +122,7 @@ func _001_initUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "001_init.up.sql", size: 2552, mode: os.FileMode(436), modTime: time.Unix(1628018891, 0)}
+	info := bindataFileInfo{name: "001_init.up.sql", size: 2552, mode: os.FileMode(420), modTime: time.Unix(1630721178, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -142,7 +142,7 @@ func _002_rwDownSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "002_rw.down.sql", size: 32, mode: os.FileMode(436), modTime: time.Unix(1631882118, 0)}
+	info := bindataFileInfo{name: "002_rw.down.sql", size: 32, mode: os.FileMode(420), modTime: time.Unix(1631886677, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -162,7 +162,7 @@ func _002_rwUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "002_rw.up.sql", size: 423, mode: os.FileMode(436), modTime: time.Unix(1631882118, 0)}
+	info := bindataFileInfo{name: "002_rw.up.sql", size: 423, mode: os.FileMode(420), modTime: time.Unix(1631886677, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -182,7 +182,7 @@ func _003_providersDownSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "003_providers.down.sql", size: 43, mode: os.FileMode(436), modTime: time.Unix(1633021059, 0)}
+	info := bindataFileInfo{name: "003_providers.down.sql", size: 43, mode: os.FileMode(420), modTime: time.Unix(1632945443, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -202,7 +202,7 @@ func _003_providersUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "003_providers.up.sql", size: 63, mode: os.FileMode(436), modTime: time.Unix(1633021059, 0)}
+	info := bindataFileInfo{name: "003_providers.up.sql", size: 63, mode: os.FileMode(420), modTime: time.Unix(1632945443, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -222,7 +222,7 @@ func _004_status_enumsDownSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "004_status_enums.down.sql", size: 1435, mode: os.FileMode(436), modTime: time.Unix(1633541920, 0)}
+	info := bindataFileInfo{name: "004_status_enums.down.sql", size: 1435, mode: os.FileMode(420), modTime: time.Unix(1633614528, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -242,7 +242,7 @@ func _004_status_enumsUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "004_status_enums.up.sql", size: 1728, mode: os.FileMode(436), modTime: time.Unix(1633541920, 0)}
+	info := bindataFileInfo{name: "004_status_enums.up.sql", size: 1728, mode: os.FileMode(420), modTime: time.Unix(1633614528, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -262,7 +262,7 @@ func _005_payload_sizeDownSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "005_payload_size.down.sql", size: 46, mode: os.FileMode(436), modTime: time.Unix(1633611889, 0)}
+	info := bindataFileInfo{name: "005_payload_size.down.sql", size: 46, mode: os.FileMode(420), modTime: time.Unix(1633614528, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -282,7 +282,7 @@ func _005_payload_sizeUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "005_payload_size.up.sql", size: 52, mode: os.FileMode(436), modTime: time.Unix(1633611889, 0)}
+	info := bindataFileInfo{name: "005_payload_size.up.sql", size: 52, mode: os.FileMode(420), modTime: time.Unix(1633614528, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/cmd/dealerd/store/migrations/migrations.go
+++ b/cmd/dealerd/store/migrations/migrations.go
@@ -98,7 +98,7 @@ func _001_initDownSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "001_init.down.sql", size: 69, mode: os.FileMode(436), modTime: time.Unix(1628018891, 0)}
+	info := bindataFileInfo{name: "001_init.down.sql", size: 69, mode: os.FileMode(420), modTime: time.Unix(1630721178, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -118,7 +118,7 @@ func _001_initUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "001_init.up.sql", size: 1333, mode: os.FileMode(436), modTime: time.Unix(1628018891, 0)}
+	info := bindataFileInfo{name: "001_init.up.sql", size: 1333, mode: os.FileMode(420), modTime: time.Unix(1630721178, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -138,7 +138,7 @@ func _002_market_statusDownSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "002_market_status.down.sql", size: 33, mode: os.FileMode(436), modTime: time.Unix(1628112604, 0)}
+	info := bindataFileInfo{name: "002_market_status.down.sql", size: 33, mode: os.FileMode(420), modTime: time.Unix(1630721178, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -158,7 +158,7 @@ func _002_market_statusUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "002_market_status.up.sql", size: 1010, mode: os.FileMode(436), modTime: time.Unix(1628112604, 0)}
+	info := bindataFileInfo{name: "002_market_status.up.sql", size: 1010, mode: os.FileMode(420), modTime: time.Unix(1630721178, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -178,7 +178,7 @@ func _003_remote_walletDownSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "003_remote_wallet.down.sql", size: 26, mode: os.FileMode(436), modTime: time.Unix(1631882118, 0)}
+	info := bindataFileInfo{name: "003_remote_wallet.down.sql", size: 26, mode: os.FileMode(420), modTime: time.Unix(1631886677, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -198,7 +198,7 @@ func _003_remote_walletUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "003_remote_wallet.up.sql", size: 437, mode: os.FileMode(436), modTime: time.Unix(1631882118, 0)}
+	info := bindataFileInfo{name: "003_remote_wallet.up.sql", size: 437, mode: os.FileMode(420), modTime: time.Unix(1631886677, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/cmd/packerd/store/migrations/migrations.go
+++ b/cmd/packerd/store/migrations/migrations.go
@@ -94,7 +94,7 @@ func _001_initDownSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "001_init.down.sql", size: 68, mode: os.FileMode(436), modTime: time.Unix(1628018891, 0)}
+	info := bindataFileInfo{name: "001_init.down.sql", size: 68, mode: os.FileMode(420), modTime: time.Unix(1630721178, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -114,7 +114,7 @@ func _001_initUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "001_init.up.sql", size: 984, mode: os.FileMode(436), modTime: time.Unix(1628018891, 0)}
+	info := bindataFileInfo{name: "001_init.up.sql", size: 984, mode: os.FileMode(420), modTime: time.Unix(1630721178, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/cmd/piecerd/store/migrations/migrations.go
+++ b/cmd/piecerd/store/migrations/migrations.go
@@ -94,7 +94,7 @@ func _001_initDownSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "001_init.down.sql", size: 68, mode: os.FileMode(436), modTime: time.Unix(1628018891, 0)}
+	info := bindataFileInfo{name: "001_init.down.sql", size: 68, mode: os.FileMode(420), modTime: time.Unix(1630721178, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -114,7 +114,7 @@ func _001_initUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "001_init.up.sql", size: 517, mode: os.FileMode(436), modTime: time.Unix(1628018891, 0)}
+	info := bindataFileInfo{name: "001_init.up.sql", size: 517, mode: os.FileMode(420), modTime: time.Unix(1630721178, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }


### PR DESCRIPTION
This is in response to the recent surge of deal errors caused by unattended miners, even though they didn't contribute to the overall error rates (via re-auction), it creates unnecessary work and noise.

The current code to calculate failure rate can not differentiate the case of deal errors vs ongoing deals, with the added column to signal errors, the failure rate can reflect provider problems more quickly.