### PR TITLE
dealer: use deadline in network stream

### DIFF
--- a/cmd/dealerd/dealer/filclient/filclient.go
+++ b/cmd/dealerd/dealer/filclient/filclient.go
@@ -432,6 +432,11 @@ func (fc *FilClient) streamToStorageProvider(
 	if err != nil {
 		return nil, fmt.Errorf("failed to open stream to peer: %w", err)
 	}
+	if deadline, ok := ctx.Deadline(); ok {
+		if err := s.SetDeadline(deadline); err != nil {
+			return nil, fmt.Errorf("set deadline of stream: %s", err)
+		}
+	}
 
 	return s, nil
 }


### PR DESCRIPTION
Yesterday night I noticed something weird in our dashboards:
![image](https://user-images.githubusercontent.com/6136245/136660701-2bcb8d1c-3642-4788-9f18-20f4d63ce662.png)

After some digging (those spikes in the silence was me testing some stuff), some particular deals were taking too much to wait for the miners response about the deal status. That felt odd since we use ctx-deadlines for things. I simply moved those deals `read_at` into the future and unclogged the rest for making progress. The reason for blocking all the pipeline is that `RateLimiter.Wait()` was waiting for those and that end up infecting both deamons just waiting forever. So that was "fixed" for the night and all good.

When getting up I realized that `network.Stream` deadline should be explicitly set and doesn't _inherit_ the semantics from `NewStream(ctx, ...)` which sounds reasonable (such as TCP conn). Surprisingly, the deals that were causing the problem now responded fine so I can't 100% test this change, but it's correct anyway to prevent this problem in the future.