### PR TITLE
ipfs-cluster update & unpinning extra log data

### DIFF
--- a/cmd/brokerd/broker/unpinner.go
+++ b/cmd/brokerd/broker/unpinner.go
@@ -70,7 +70,7 @@ func (b *Broker) unpinCid(ctx context.Context, uj store.UnpinJob) (err error) {
 		//          We should change this whenever the bug is resolved.
 		var ctmErr *cmds.Error
 		if ok := errors.As(err, &ctmErr); ok && ctmErr.Code == 0 {
-			log.Warnf("%s unpinning was skipped due to ipfs-cluster known bug", uj.Cid)
+			log.Warnf("%s unpinning was skipped due to ipfs-cluster known bug: %s", uj.Cid, err)
 			return nil
 		}
 		return fmt.Errorf("unpinning %s: %s", uj.Cid, err)

--- a/k8/base/ipfs-cluster/cluster-statefulset.yaml
+++ b/k8/base/ipfs-cluster/cluster-statefulset.yaml
@@ -69,7 +69,7 @@ spec:
           resources:
             {}
         - name: ipfs-cluster
-          image: "ipfs/ipfs-cluster:v0.14.0"
+          image: "ipfs/ipfs-cluster:v0.14.1"
           command: ["sh", "/custom/cluster-entrypoint.sh"]
           envFrom:
             - configMapRef:


### PR DESCRIPTION
I'm checking some invariants about unpinning.
Mostly here adding some extra logging for a thing I'm interested in now, and updating ipfs-cluster version.