### PR TITLE
Testing actions, commit that should fail linting

### DIFF
--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -55,3 +55,7 @@ func StopServer(s *grpc.Server) {
 		timer.Stop()
 	}
 }
+
+func Foo(s string) string {
+	return "foo"
+}


### PR DESCRIPTION
This adds an exported function `Foo` that has no comment.  It breaks linting for me locally, and I want to make sure the github action fails