### PR TITLE
auctioneer: increase timeout for re-processing stuck auctions

### DIFF
--- a/cmd/auctioneerd/auctioneer/queue/queue.go
+++ b/cmd/auctioneerd/auctioneer/queue/queue.go
@@ -30,7 +30,7 @@ var (
 
 	// stuckSeconds is the seconds elapsed before an started auction is
 	// considered stuck and can be rescheduled.
-	stuckSeconds = int64(600)
+	stuckSeconds = int64(3600)
 
 	// MaxConcurrency is the maximum number of auctions that will be handled concurrently.
 	MaxConcurrency = 1


### PR DESCRIPTION
This PR increases the timeout for re-processing auctions that _seem_ stuck. The previous timeout was short.

Long explanation:
- [High level explanation](https://textileio.slack.com/archives/C029VRX7X4M/p1639604403161300?thread_ts=1639599682.159000&cid=C029VRX7X4M)
- In this [log chunk](https://cloudlogging.app.goo.gl/4kyUx6D1e3mNAmR58) we can see how `{"caller":"queue/queue.go:552", "logger":"auctioneer/queue", "msg":"got auction from DB: 01fnqbfse8tjy072vgha14kss0", "ts":"2021-11-30T06:43:43.090Z"}
` happened in the middle of the same auction run. The only way the executing auction can be gathered again to execute is via the "stuck timeout" logic, which was 10min. Seeing the other log lines we can see that the auction took longer to provide a signal of finishing.

Switching now to 1hr timeout. We have to be really sure about apparently "stuck" executing things for being re-executed. The risk-on falling short in these timeouts is re-executing things that shouldn't be re-executed.

Note: it isn't necessary to read the explanation or logs for review. Just leaving that as detailed information about the bug analysis.