### PR TITLE
Ignore the DS Store file on Mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 *.so
 *.dylib
 
+# Ignore Mac system files
+.DS_store
+
 # Test binary, built with `go test -c`
 *.test
 


### PR DESCRIPTION
A small proposal mostly for devs using mac. It adds a `gitignore` item to exclude system files created by MacOS in every directory.