### PR TITLE
Skip the deadline check for D2P auctions

### DIFF
--- a/cmd/auctioneerd/auctioneer/auctioneer.go
+++ b/cmd/auctioneerd/auctioneer/auctioneer.go
@@ -513,7 +513,7 @@ func (a *Auctioneer) selectWinners(
 		// consider only bids with zero price for now.
 		return !auction.DealVerified && b.AskPrice == 0 || auction.DealVerified && b.VerifiedAskPrice == 0
 	})
-	if auction.FilEpochDeadline > 0 {
+	if auction.FilEpochDeadline > 0 && len(auction.Providers) <= 0 {
 		// select providers historically (the recent week) confirmed deals sooner than the auction requires.
 		current := currentFilEpoch()
 		if auction.FilEpochDeadline <= current {

--- a/cmd/auctioneerd/auctioneer/auctioneer_internal_test.go
+++ b/cmd/auctioneerd/auctioneer/auctioneer_internal_test.go
@@ -153,6 +153,15 @@ func TestSelectWinners(t *testing.T) {
 			}{{[]core.BidID{"bid1", "bid3", "bid5", "bid7"}, 1.0}},
 		},
 		{
+			"targeted auctions with deadline passed, should still select given providers",
+			auctioneer.Auction{DealReplication: 4, Providers: []string{"sp1", "sp3", "sp5", "sp7"},
+				FilEpochDeadline: currentFilEpoch() - 86400},
+			[]struct {
+				ids    []core.BidID
+				chance float64
+			}{{[]core.BidID{"bid1", "bid3", "bid5", "bid7"}, 1.0}},
+		},
+		{
 			"targeted auctions with more bids, still follow the replica rules",
 			auctioneer.Auction{DealReplication: 1, Providers: []string{"sp1", "sp2", "sp3", "sp4", "sp5", "sp7"},
 				FilEpochDeadline: currentFilEpoch() + 10},


### PR DESCRIPTION
In the case of D2P auctions, deadlines lose relevance. Since we already know that the given list of providers is already chosen, we can skip the deadline expiration check. 

Currently, we are checking for the deadline, and if the storage providers do not bid within time "insufficient bid" error is raised.